### PR TITLE
Remove cosign version constraint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Cosign Install
         uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v2.0.0-rc.0'
 
       - name: Set up container metadata
         id: meta


### PR DESCRIPTION
No longer need a release candidate, so let's just keep up with the latest releases.